### PR TITLE
Manage local storage in lists

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,6 +163,7 @@ import { ModelIcon } from './resources/models/icon';
 import runDefinition from './resources/runs';
 import { StompContextProvider } from './contexts/StompContext';
 import { ProjectLineage } from './pages/lineage/ProjectLineage';
+import { StoreResetter } from './components/StoreResetter';
 
 export const SearchEnabledContext = createContext(false);
 
@@ -191,123 +192,125 @@ const CoreApp = () => {
                 authProvider={authProvider}
                 store={localStorageStore('dh')}
             >
-                <SearchContextProvider searchProvider={dataProvider}>
-                    <ResourceSchemaProvider
-                        dataProvider={dataProvider}
-                        resource="schemas"
-                    >
-                        <StompContextProvider
-                            authProvider={authProvider}
-                            websocketUrl={WEBSOCKET_URL}
-                            topics={['/user/notifications/runs']}
+                <StoreResetter>
+                    <SearchContextProvider searchProvider={dataProvider}>
+                        <ResourceSchemaProvider
+                            dataProvider={dataProvider}
+                            resource="schemas"
                         >
-                            <AdminUI
-                                dashboard={Dashboard}
-                                layout={WrappedLayout}
-                                loginPage={MyLoginPage}
-                                requireAuth={!!authProvider}
-                                disableTelemetry
+                            <StompContextProvider
+                                authProvider={authProvider}
+                                websocketUrl={WEBSOCKET_URL}
+                                topics={['/user/notifications/runs']}
                             >
-                                <Resource
-                                    name="functions"
-                                    list={FunctionList}
-                                    show={FunctionShow}
-                                    edit={FunctionEdit}
-                                    create={FunctionCreate}
-                                    icon={FunctionIcon}
-                                />
-                                <Resource
-                                    name="workflows"
-                                    list={WorkflowList}
-                                    show={WorkflowShow}
-                                    edit={WorkflowEdit}
-                                    create={WorkflowCreate}
-                                    icon={WorkflowIcon}
-                                />
-                                <Resource
-                                    name="dataitems"
-                                    list={DataItemList}
-                                    show={DataItemShow}
-                                    edit={DataItemEdit}
-                                    create={DataItemCreate}
-                                    icon={DataItemIcon}
+                                <AdminUI
+                                    dashboard={Dashboard}
+                                    layout={WrappedLayout}
+                                    loginPage={MyLoginPage}
+                                    requireAuth={!!authProvider}
+                                    disableTelemetry
                                 >
-                                    <Route
-                                        path=":id/update"
-                                        element={<DataItemUpdate />}
+                                    <Resource
+                                        name="functions"
+                                        list={FunctionList}
+                                        show={FunctionShow}
+                                        edit={FunctionEdit}
+                                        create={FunctionCreate}
+                                        icon={FunctionIcon}
                                     />
-                                </Resource>
-                                <Resource
-                                    name="models"
-                                    list={ModelList}
-                                    show={ModelShow}
-                                    edit={ModelEdit}
-                                    create={ModelCreate}
-                                    icon={ModelIcon}
-                                >
-                                    <Route
-                                        path=":id/update"
-                                        element={<ModelUpdate />}
+                                    <Resource
+                                        name="workflows"
+                                        list={WorkflowList}
+                                        show={WorkflowShow}
+                                        edit={WorkflowEdit}
+                                        create={WorkflowCreate}
+                                        icon={WorkflowIcon}
                                     />
-                                </Resource>
-                                <Resource
-                                    name="artifacts"
-                                    list={ArtifactList}
-                                    show={ArtifactShow}
-                                    edit={ArtifactEdit}
-                                    create={ArtifactCreate}
-                                    icon={ArtifactIcon}
-                                >
-                                    <Route
-                                        path=":id/update"
-                                        element={<ArtifactUpdate />}
+                                    <Resource
+                                        name="dataitems"
+                                        list={DataItemList}
+                                        show={DataItemShow}
+                                        edit={DataItemEdit}
+                                        create={DataItemCreate}
+                                        icon={DataItemIcon}
+                                    >
+                                        <Route
+                                            path=":id/update"
+                                            element={<DataItemUpdate />}
+                                        />
+                                    </Resource>
+                                    <Resource
+                                        name="models"
+                                        list={ModelList}
+                                        show={ModelShow}
+                                        edit={ModelEdit}
+                                        create={ModelCreate}
+                                        icon={ModelIcon}
+                                    >
+                                        <Route
+                                            path=":id/update"
+                                            element={<ModelUpdate />}
+                                        />
+                                    </Resource>
+                                    <Resource
+                                        name="artifacts"
+                                        list={ArtifactList}
+                                        show={ArtifactShow}
+                                        edit={ArtifactEdit}
+                                        create={ArtifactCreate}
+                                        icon={ArtifactIcon}
+                                    >
+                                        <Route
+                                            path=":id/update"
+                                            element={<ArtifactUpdate />}
+                                        />
+                                    </Resource>
+                                    <Resource name="tasks" />
+                                    <Resource {...runDefinition} />
+                                    <Resource
+                                        name="projects"
+                                        list={ProjectSelectorList}
+                                        edit={ProjectEdit}
+                                        create={ProjectCreate}
                                     />
-                                </Resource>
-                                <Resource name="tasks" />
-                                <Resource {...runDefinition} />
-                                <Resource
-                                    name="projects"
-                                    list={ProjectSelectorList}
-                                    edit={ProjectEdit}
-                                    create={ProjectCreate}
-                                />
-                                <Resource name="schemas" />
-                                <Resource name="logs" />
-                                <Resource name="metadatas" />
-                                <Resource
-                                    name="secrets"
-                                    list={SecretList}
-                                    show={SecretShow}
-                                    edit={SecretEdit}
-                                    create={SecretCreate}
-                                    icon={SecretIcon}
-                                ></Resource>
-                                <Resource name="labels" />
-                                <Resource name="templates" />
-                                <CustomRoutes>
-                                    <Route
-                                        path="/config"
-                                        element={<ProjectConfig />}
-                                    />
-                                </CustomRoutes>
-                                <CustomRoutes>
-                                    <Route
-                                        path="/lineage"
-                                        element={<ProjectLineage />}
-                                    />
-                                </CustomRoutes>
-                                {enableSearch && (
+                                    <Resource name="schemas" />
+                                    <Resource name="logs" />
+                                    <Resource name="metadatas" />
+                                    <Resource
+                                        name="secrets"
+                                        list={SecretList}
+                                        show={SecretShow}
+                                        edit={SecretEdit}
+                                        create={SecretCreate}
+                                        icon={SecretIcon}
+                                    ></Resource>
+                                    <Resource name="labels" />
+                                    <Resource name="templates" />
                                     <CustomRoutes>
                                         <Route
-                                            path="/searchresults"
-                                            element={<SearchList />}
+                                            path="/config"
+                                            element={<ProjectConfig />}
                                         />
                                     </CustomRoutes>
-                                )}
-                            </AdminUI>
-                        </StompContextProvider>
-                    </ResourceSchemaProvider>
-                </SearchContextProvider>
+                                    <CustomRoutes>
+                                        <Route
+                                            path="/lineage"
+                                            element={<ProjectLineage />}
+                                        />
+                                    </CustomRoutes>
+                                    {enableSearch && (
+                                        <CustomRoutes>
+                                            <Route
+                                                path="/searchresults"
+                                                element={<SearchList />}
+                                            />
+                                        </CustomRoutes>
+                                    )}
+                                </AdminUI>
+                            </StompContextProvider>
+                        </ResourceSchemaProvider>
+                    </SearchContextProvider>
+                </StoreResetter>
             </AdminContext>
         </RootSelectorContextProvider>
     );

--- a/src/components/ShowToolbar.tsx
+++ b/src/components/ShowToolbar.tsx
@@ -80,7 +80,7 @@ export const ShowToolbar = () => {
                 confirmContent={confirmContent}
                 deleteAll={checked}
                 redirect={redirect}
-                translateOptions={{ id: record.id }}
+                translateOptions={{ id: record?.id }}
             />
         </TopToolbar>
     );

--- a/src/components/StoreResetter.tsx
+++ b/src/components/StoreResetter.tsx
@@ -1,0 +1,32 @@
+import { useRootSelector } from '@dslab/ra-root-selector';
+import { useEffect, useRef } from 'react';
+import {
+    AdminChildren,
+    getStorage,
+    useRemoveFromStore,
+} from 'react-admin';
+import { isEqual } from 'lodash';
+
+export const StoreResetter = ({ children }: { children?: AdminChildren }) => {
+    const { root } = useRootSelector();
+    const remove = useRemoveFromStore();
+    const prevRoot = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!isEqual(root, prevRoot.current)) {
+            console.log('resetting selection state');
+            prevRoot.current = root ?? null;
+
+            //clear selection state
+            const storageKeys = Object.keys(getStorage());
+            storageKeys.forEach(k => {
+                if (k.endsWith('selectedIds')) {
+                    const keyParts = k.split('.');
+                    remove(`${keyParts[1]}.selectedIds`);
+                }
+            });
+        }
+    }, [remove, root]);
+
+    return <>{children}</>;
+};

--- a/src/resources/artifacts/list.tsx
+++ b/src/resources/artifacts/list.tsx
@@ -17,7 +17,6 @@ import {
     useExpanded,
     useRecordContext,
     useResourceContext,
-    useTranslate,
 } from 'react-admin';
 import { DeleteWithConfirmButtonByName } from '../../components/DeleteWithConfirmButtonByName';
 import { FlatCard } from '../../components/FlatCard';
@@ -29,6 +28,7 @@ import { ArtifactIcon } from './icon';
 import { ImportButton } from '../../components/ImportButton';
 import { ChipsField } from '../../components/ChipsField';
 import { BulkDeleteAllVersions } from '../../components/BulkDeleteAllVersions';
+import { useRootSelector } from '@dslab/ra-root-selector';
 
 const ListToolbar = () => {
     return (
@@ -58,7 +58,8 @@ const RowActions = () => {
 };
 
 export const ArtifactList = () => {
-    const translate = useTranslate();
+    const resource = useResourceContext();
+    const { root } = useRootSelector();
     const schemaProvider = useSchemaProvider();
     const [kinds, setKinds] = useState<any[]>();
 
@@ -101,6 +102,7 @@ export const ArtifactList = () => {
             <ListBase
                 exporter={yamlExporter}
                 sort={{ field: 'metadata.updated', order: 'DESC' }}
+                storeKey={`${root}.${resource}.listParams`}
             >
                 <>
                     <ListPageTitle icon={<ArtifactIcon fontSize={'large'} />} />

--- a/src/resources/dataitems/list.tsx
+++ b/src/resources/dataitems/list.tsx
@@ -17,7 +17,6 @@ import {
     useExpanded,
     useRecordContext,
     useResourceContext,
-    useTranslate,
 } from 'react-admin';
 import { DeleteWithConfirmButtonByName } from '../../components/DeleteWithConfirmButtonByName';
 import { FlatCard } from '../../components/FlatCard';
@@ -29,6 +28,7 @@ import { DataItemIcon } from './icon';
 import { ImportButton } from '../../components/ImportButton';
 import { ChipsField } from '../../components/ChipsField';
 import { BulkDeleteAllVersions } from '../../components/BulkDeleteAllVersions';
+import { useRootSelector } from '@dslab/ra-root-selector';
 
 const ListToolbar = () => {
     return (
@@ -58,7 +58,8 @@ const RowActions = () => {
 };
 
 export const DataItemList = () => {
-    const translate = useTranslate();
+    const resource = useResourceContext();
+    const { root } = useRootSelector();
     const schemaProvider = useSchemaProvider();
     const [kinds, setKinds] = useState<any[]>();
 
@@ -101,6 +102,7 @@ export const DataItemList = () => {
             <ListBase
                 exporter={yamlExporter}
                 sort={{ field: 'metadata.updated', order: 'DESC' }}
+                storeKey={`${root}.${resource}.listParams`}
             >
                 <>
                     <ListPageTitle icon={<DataItemIcon fontSize={'large'} />} />

--- a/src/resources/functions/list.tsx
+++ b/src/resources/functions/list.tsx
@@ -17,7 +17,6 @@ import {
     useExpanded,
     useRecordContext,
     useResourceContext,
-    useTranslate,
 } from 'react-admin';
 import { DeleteWithConfirmButtonByName } from '../../components/DeleteWithConfirmButtonByName';
 import { FlatCard } from '../../components/FlatCard';
@@ -29,6 +28,7 @@ import { FunctionIcon } from './icon';
 import { ImportButton } from '../../components/ImportButton';
 import { ChipsField } from '../../components/ChipsField';
 import { BulkDeleteAllVersions } from '../../components/BulkDeleteAllVersions';
+import { useRootSelector } from '@dslab/ra-root-selector';
 
 const ListToolbar = () => {
     return (
@@ -58,7 +58,8 @@ const RowActions = () => {
 };
 
 export const FunctionList = () => {
-    const translate = useTranslate();
+    const resource = useResourceContext();
+    const { root } = useRootSelector();
     const schemaProvider = useSchemaProvider();
     const [kinds, setKinds] = useState<any[]>();
 
@@ -101,6 +102,7 @@ export const FunctionList = () => {
             <ListBase
                 exporter={yamlExporter}
                 sort={{ field: 'metadata.updated', order: 'DESC' }}
+                storeKey={`${root}.${resource}.listParams`}
             >
                 <>
                     <ListPageTitle icon={<FunctionIcon fontSize={'large'} />} />

--- a/src/resources/models/list.tsx
+++ b/src/resources/models/list.tsx
@@ -17,7 +17,6 @@ import {
     useExpanded,
     useRecordContext,
     useResourceContext,
-    useTranslate,
 } from 'react-admin';
 import { DeleteWithConfirmButtonByName } from '../../components/DeleteWithConfirmButtonByName';
 import { FlatCard } from '../../components/FlatCard';
@@ -29,6 +28,7 @@ import { ModelIcon } from './icon';
 import { ImportButton } from '../../components/ImportButton';
 import { ChipsField } from '../../components/ChipsField';
 import { BulkDeleteAllVersions } from '../../components/BulkDeleteAllVersions';
+import { useRootSelector } from '@dslab/ra-root-selector';
 
 const ListToolbar = () => {
     return (
@@ -58,7 +58,8 @@ const RowActions = () => {
 };
 
 export const ModelList = () => {
-    const translate = useTranslate();
+    const resource = useResourceContext();
+    const { root } = useRootSelector();
     const schemaProvider = useSchemaProvider();
     const [kinds, setKinds] = useState<any[]>();
 
@@ -101,6 +102,7 @@ export const ModelList = () => {
             <ListBase
                 exporter={yamlExporter}
                 sort={{ field: 'metadata.updated', order: 'DESC' }}
+                storeKey={`${root}.${resource}.listParams`}
             >
                 <>
                     <ListPageTitle icon={<ModelIcon fontSize={'large'} />} />

--- a/src/resources/runs/list.tsx
+++ b/src/resources/runs/list.tsx
@@ -9,6 +9,7 @@ import {
     TextField,
     TextInput,
     TopToolbar,
+    useResourceContext,
     useTranslate,
 } from 'react-admin';
 import { Box, Container } from '@mui/material';
@@ -21,6 +22,7 @@ import { useSchemaProvider } from '../../provider/schemaProvider';
 import { StateChips, StateColors } from '../../components/StateChips';
 import { RunIcon } from './icon';
 import { BulkDeleteAllVersions } from '../../components/BulkDeleteAllVersions';
+import { useRootSelector } from '@dslab/ra-root-selector';
 
 const ListToolbar = () => {
     return <TopToolbar />;
@@ -37,6 +39,8 @@ const RowActions = () => {
 
 export const RunList = () => {
     const translate = useTranslate();
+    const resource = useResourceContext();
+    const { root } = useRootSelector();
     const schemaProvider = useSchemaProvider();
     const [kinds, setKinds] = useState<any[]>();
 
@@ -86,11 +90,13 @@ export const RunList = () => {
               />,
           ]
         : [];
+
     return (
         <Container maxWidth={false} sx={{ pb: 2 }}>
             <ListBase
                 exporter={yamlExporter}
                 sort={{ field: 'metadata.updated', order: 'DESC' }}
+                storeKey={`${root}.${resource}.listParams`}
             >
                 <>
                     <ListPageTitle icon={<RunIcon fontSize={'large'} />} />

--- a/src/resources/secrets/list.tsx
+++ b/src/resources/secrets/list.tsx
@@ -9,6 +9,7 @@ import {
     ShowButton,
     TextField,
     TopToolbar,
+    useResourceContext,
 } from 'react-admin';
 
 import { SecretIcon } from './icon';
@@ -17,6 +18,7 @@ import { ListPageTitle } from '../../components/PageTitle';
 import { FlatCard } from '../../components/FlatCard';
 import { RowButtonGroup } from '../../components/RowButtonGroup';
 import { BulkDeleteAllVersions } from '../../components/BulkDeleteAllVersions';
+import { useRootSelector } from '@dslab/ra-root-selector';
 
 const ListToolbar = () => {
     return (
@@ -37,9 +39,15 @@ const RowActions = () => {
 };
 
 export const SecretList = () => {
+    const resource = useResourceContext();
+    const { root } = useRootSelector();
+
     return (
         <Container maxWidth={false} sx={{ pb: 2 }}>
-            <ListBase exporter={yamlExporter}>
+            <ListBase
+                exporter={yamlExporter}
+                storeKey={`${root}.${resource}.listParams`}
+            >
                 <>
                     <ListPageTitle icon={<SecretIcon fontSize={'large'} />} />
                     <ListToolbar />

--- a/src/resources/workflows/list.tsx
+++ b/src/resources/workflows/list.tsx
@@ -17,7 +17,6 @@ import {
     useExpanded,
     useRecordContext,
     useResourceContext,
-    useTranslate,
 } from 'react-admin';
 import { DeleteWithConfirmButtonByName } from '../../components/DeleteWithConfirmButtonByName';
 import { FlatCard } from '../../components/FlatCard';
@@ -29,6 +28,7 @@ import { WorkflowIcon } from './icon';
 import { ImportButton } from '../../components/ImportButton';
 import { ChipsField } from '../../components/ChipsField';
 import { BulkDeleteAllVersions } from '../../components/BulkDeleteAllVersions';
+import { useRootSelector } from '@dslab/ra-root-selector';
 
 const ListToolbar = () => {
     return (
@@ -58,7 +58,8 @@ const RowActions = () => {
 };
 
 export const WorkflowList = () => {
-    const translate = useTranslate();
+    const resource = useResourceContext();
+    const { root } = useRootSelector();
     const schemaProvider = useSchemaProvider();
     const [kinds, setKinds] = useState<any[]>();
 
@@ -101,6 +102,7 @@ export const WorkflowList = () => {
             <ListBase
                 exporter={yamlExporter}
                 sort={{ field: 'metadata.updated', order: 'DESC' }}
+                storeKey={`${root}.${resource}.listParams`}
             >
                 <>
                     <ListPageTitle icon={<WorkflowIcon fontSize={'large'} />} />


### PR DESCRIPTION
`storeKey` prop prefixed with project name in lists of resources that are synchronized with the store (i.e. without `disableSyncWithLocation` prop). `AdminContext ` children wrapped in a component that resets the selection state in response to switching to a different project.

Notes:
- multiple lists of the same resource (e.g. runs) within the same project keep sharing the same selection state by React-Admin design (see [List.storeKey)](https://marmelab.com/react-admin/List.html#storekey)
- when the user navigates from project A to the list of projects and chooses again project A, the previous selection state is reset anyway because the wrapper component is recreated