### PR TITLE
fix: Ajv validation for path

### DIFF
--- a/src/pages/secrets/create.tsx
+++ b/src/pages/secrets/create.tsx
@@ -38,9 +38,16 @@ export const SecretCreate = () => {
     //hardcoded: only 1 kind supported
     const kind = 'secret';
     const uiSchema = SecretUiSchema;
-    const schema = schemas ? schemas.find(s => s.kind == kind)?.schema : {};
+    const rawSchema = schemas ? schemas.find(s => s.kind === kind)?.schema : {};
+    const schema = rawSchema
+        ? {
+              ...rawSchema,
+              required:
+                  rawSchema.required?.filter((f: string) => f !== 'path') ?? [],
+          }
+        : {};
 
-    const record = { kind };
+    const record = { kind, spec: { provider: 'kubernetes' } };
 
     //TODO move to server or refactor
     const checkDuplicates = data => {


### PR DESCRIPTION
**Make path optional during validation and populate it in transform**

When a user enters a name and clicks Save, the form submission flow calls validate() before transform(). At validation time, spec only contains **{ provider: 'kubernetes' }**, so path has not been set yet. This caused AJV to fail with "path is required".

To resolve this, path is removed from the schema’s required array before AJV validation runs. The transform() step then sets path to **secret://name** after validation. The record also initializes spec with **{ provider: 'kubernetes' }** so the provider field is prefilled by default.
